### PR TITLE
Prepare package metadata for PyPI model packs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 # Future Work
 
-- Decide whether `rvc3python` should be an explicit `ir-support` dependency, or a documented optional install target, so a fresh student environment can install IR Support without separately remembering the Robotics Toolbox stack. This should be handled together with the planned dependency/Python-version modernisation work.
+- Review dependency pins and supported Python versions together, with a target of moving beyond Python 3.10 once the Robotics Toolbox/Open3D/Swift stack is verified.
 - Review `Files/Labs/bagreader.py`: it imports `bagpy`, but `bagpy==0.5` pins `Jinja2<3.1` and conflicts with the current Flask/Open3D stack. Keep it out of the standard student install unless we replace or isolate that bag-reading workflow.

--- a/ir_support_extra_parts/pyproject.toml
+++ b/ir_support_extra_parts/pyproject.toml
@@ -9,10 +9,8 @@ include = ["ir_support_extra_parts/**/*.dae", "ir_support_extra_parts/**/*.txt",
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
-ir-support = ">=1.2.6"
+ir-support = ">=1.3.0,<2.0.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-

--- a/ir_support_extra_robots/pyproject.toml
+++ b/ir_support_extra_robots/pyproject.toml
@@ -9,9 +9,8 @@ include = ["ir_support_extra_robots/**/*.dae", "ir_support_extra_robots/**/*.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
-ir-support = ">=1.2.6"
+ir-support = ">=1.3.0,<2.0.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ir-support"
-version = "1.2.6"
+version = "1.3.0"
 description = "Python package including some classes & functions supporting the subject 41013 Industrial Robotics at UTS, along with the Robotics Toolbox for Python"
 authors = [
     "41013 Teaching Team <41013@uts.edu.au>",
@@ -32,6 +32,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
+rvc3python = ">=0.9.2,<0.10.0"
 pandas = ">=2.0.3,<2.2.2"
 trimesh = ">=4.0.0,<4.4.4"
 plyfile = ">=1.0.1,<1.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Kept for GitHub dependency scanning and simple pip-based development installs.
 # For package metadata and release builds, prefer pyproject.toml/Poetry.
+rvc3python>=0.9.2,<0.10.0
 pandas>=2.0.3,<2.2.2
 trimesh>=4.0.0,<4.4.4
 plyfile>=1.0.1,<1.0.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ir_support",
-    version="1.1.0b",
+    version="1.3.0",
     description="Python package including some classes & functions supporting the subject 41013 Industrial Robotics at UTS, along with the Robotics Toolbox for Python",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -17,8 +17,9 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.8,<3.12",
-    packages=find_packages(include=["ir_support"]),
+    packages=find_packages(include=["ir_support", "ir_support.*"]),
     install_requires=[
+        "rvc3python>=0.9.2,<0.10.0",
         "pandas>=2.0.3,<2.2.2",
         "trimesh>=4.0.0,<4.4.4",
         "plyfile>=1.0.1,<1.0.2",
@@ -28,6 +29,8 @@ setup(
         "open3d>=0.18.0",
         "spatialmath-python==1.1.8",
         "matplotlib==3.7.2",
+        "pygame==2.6.1",
+        "line_profiler==4.2.0",
     ],
     url="https://github.com/gapaul/ir-support",
     author="Quang Ngo",


### PR DESCRIPTION
Updates packaging metadata for the upcoming PyPI release.

This bumps ir-support to 1.3.0, adds rvc3python as the core Robotics Toolbox dependency so clean installs can import ir_support successfully, and makes the optional extra robot and parts packages depend on the updated core package.

Local validation:
- Built wheels and source distributions for ir-support, ir-support-extra-robots, and ir-support-extra-parts
- twine check passed for all artifacts
- Fresh wheel-install venv passed pip check
- Top-level imports and sample robot/part loads passed
- pytest: 61 passed