### PR TITLE
ir_support_full as a tiny meta-package

### DIFF
--- a/ir_support_full/README.md
+++ b/ir_support_full/README.md
@@ -1,0 +1,15 @@
+# ir-support-full
+
+`ir-support-full` is a small meta-package for 41013 Industrial Robotics at UTS. It installs the core `ir-support` package plus the optional robot and parts model packs:
+
+- `ir-support`
+- `ir-support-extra-robots`
+- `ir-support-extra-parts`
+
+Use this when you want the complete local model library rather than only the lab-required core package.
+
+```powershell
+python -m pip install ir-support-full
+```
+
+The installed importable packages remain `ir_support`, `ir_support_extra_robots`, and `ir_support_extra_parts`.

--- a/ir_support_full/ir_support_full/__init__.py
+++ b/ir_support_full/ir_support_full/__init__.py
@@ -1,0 +1,3 @@
+"""Meta-package marker for installing the complete IR Support model set."""
+
+__version__ = "0.1.0"

--- a/ir_support_full/pyproject.toml
+++ b/ir_support_full/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "ir-support-full"
+version = "0.1.0"
+description = "Meta-package that installs ir-support and the optional robot and parts model packs."
+authors = ["41013 Teaching Team <41013@uts.edu.au>"]
+readme = "README.md"
+packages = [{include = "ir_support_full"}]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.11"
+ir-support = ">=1.3.0,<2.0.0"
+ir-support-extra-robots = ">=0.1.0,<0.2.0"
+ir-support-extra-parts = ">=0.1.0,<0.2.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I created ir_support_full/ as a tiny meta-package. It does not contain models itself; it just installs:

ir-support
ir-support-extra-robots
ir-support-extra-parts

It correctly pulled all three packages from PyPI and the imports/smoke tests passed.